### PR TITLE
Fix generation of alphanumeric strings

### DIFF
--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -102,19 +102,22 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-
 	RandomString, err := Random(count, 0, 0, true, true)
 	if err != nil {
 		return "", fmt.Errorf("Error: %s", err)
 	}
 	match, _ := regexp.MatchString("([0-9]+)", RandomString)
 
-	for match == false {
-		RandomString, err = Random(count, 0, 0, true, true)
-		match, _ = regexp.MatchString("([0-9]+)", RandomString)
+	if match == false {
+		//Get the position between 0 and the length of the string-1  to insert a random number
+		position := rand.Intn(count - 1)
+		fmt.Println("Generated number: ", position)
+		//Insert a random number between [0-9] in the position
+		RandomString = RandomString[:position] + string(rand.Intn(9)) + RandomString[position+1:]
+		return RandomString, err
 	}
-
 	return RandomString, err
+
 }
 
 /*

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -106,7 +106,10 @@ func RandomAlphaNumeric(count int) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Error: %s", err)
 	}
-	match, _ := regexp.MatchString("([0-9]+)", RandomString)
+	match, err := regexp.MatchString("([0-9]+)", RandomString)
+	if err != nil {
+		panic(err)
+	}
 
 	if !match {
 		//Get the position between 0 and the length of the string-1  to insert a random number

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
+	"strings"
 	"time"
 	"unicode"
 )
@@ -108,9 +109,12 @@ func RandomAlphaNumeric(count int) (string, error) {
 	}
 	match, _ := regexp.MatchString("([0-9]+)", RandomString)
 
-	if match == false {
+	if !match {
+		fmt.Println("I was going to generate.. ", RandomString)
 		//Get the position between 0 and the length of the string-1  to insert a random number
 		position := rand.Intn(count - 1)
+		strings.Replace(RandomString)
+
 		fmt.Println("Generated number: ", position)
 		//Insert a random number between [0-9] in the position
 		RandomString = RandomString[:position] + string(rand.Intn(9)) + RandomString[position+1:]

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
-	"strings"
+	"strconv"
 	"time"
 	"unicode"
 )
@@ -110,14 +110,10 @@ func RandomAlphaNumeric(count int) (string, error) {
 	match, _ := regexp.MatchString("([0-9]+)", RandomString)
 
 	if !match {
-		fmt.Println("I was going to generate.. ", RandomString)
 		//Get the position between 0 and the length of the string-1  to insert a random number
 		position := rand.Intn(count - 1)
-		strings.Replace(RandomString)
-
-		fmt.Println("Generated number: ", position)
 		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string(rand.Intn(9)) + RandomString[position+1:]
+		RandomString = RandomString[:position] + strconv.Itoa(rand.Intn(9)) + RandomString[position+1:]
 		return RandomString, err
 	}
 	return RandomString, err

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
-	"strconv"
 	"time"
 	"unicode"
 )
@@ -111,9 +110,9 @@ func RandomAlphaNumeric(count int) (string, error) {
 
 	if !match {
 		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count - 1)
+		position := rand.Intn(count)
 		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + strconv.Itoa(rand.Intn(9)) + RandomString[position+1:]
+		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
 		return RandomString, err
 	}
 	return RandomString, err

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"regexp"
 	"time"
 	"unicode"
 )
@@ -101,7 +102,19 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	return Random(count, 0, 0, true, true)
+
+	RandomString, err := Random(count, 0, 0, true, true)
+	if err != nil {
+		return "", fmt.Errorf("Error: %s", err)
+	}
+	match, _ := regexp.MatchString("([0-9]+)", RandomString)
+
+	for match == false {
+		RandomString, err = Random(count, 0, 0, true, true)
+		match, _ = regexp.MatchString("([0-9]+)", RandomString)
+	}
+
+	return RandomString, err
 }
 
 /*

--- a/randomstringutils_test.go
+++ b/randomstringutils_test.go
@@ -2,8 +2,11 @@ package goutils
 
 import (
 	"fmt"
+	"goutils"
 	"math/rand"
+	"regexp"
 	"testing"
+	"time"
 )
 
 // ****************************** TESTS ********************************************
@@ -75,4 +78,21 @@ func ExampleRandomSeed() {
 	// 88935
 	// H_I;E
 	// 2b2ca
+}
+
+func ExampleAlphaNumericString() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	for index := 0; index < 15; index++ {
+		testString, err := goutils.RandomAlphaNumeric(15)
+		if err != nil {
+			fmt.Println("Error generating string")
+		}
+		fmt.Println("RandomString: ", testString)
+		match, _ := regexp.MatchString("([0-9]+)", a)
+		if !match {
+			return fmt.Errorf("Error: There are some alphanumeric strings containing only letters")
+		}
+
+	}
 }

--- a/randomstringutils_test.go
+++ b/randomstringutils_test.go
@@ -2,11 +2,8 @@ package goutils
 
 import (
 	"fmt"
-	"goutils"
 	"math/rand"
-	"regexp"
 	"testing"
-	"time"
 )
 
 // ****************************** TESTS ********************************************
@@ -78,21 +75,4 @@ func ExampleRandomSeed() {
 	// 88935
 	// H_I;E
 	// 2b2ca
-}
-
-func ExampleAlphaNumericString() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	for index := 0; index < 15; index++ {
-		testString, err := goutils.RandomAlphaNumeric(15)
-		if err != nil {
-			fmt.Println("Error generating string")
-		}
-		fmt.Println("RandomString: ", testString)
-		match, _ := regexp.MatchString("([0-9]+)", a)
-		if !match {
-			return fmt.Errorf("Error: There are some alphanumeric strings containing only letters")
-		}
-
-	}
 }


### PR DESCRIPTION
Hi all!
I found an issue in the kubernetes helm charts due to the generation of alpha numeric strings.
Currently, the [helm chart of Magento](https://github.com/kubernetes/charts/tree/master/stable/magento) is using the `randAlphaNum` to generate the password of the application in the [secrets.yaml](https://github.com/kubernetes/charts/blob/master/stable/magento/templates/secrets.yaml):
 
  `magento-password: {{ randAlphaNum 10 | b64enc | quote }}`

In each deploy Magento checks if the password of the application is alpha numeric, and following your library and making a simple test I can see that not every time the string generated is alpha numeric. Here you can see a simple script that generates random alpha numeric strings:

```
package main

import (
	"fmt"
	"goutils"
	"regexp"
)
func main() {
	for index := 0; index < 10000; index++ {
		a, err := goutils.RandomAlphaNumeric(10)
		if err != nil {
			fmt.Println("Err != nil")
		}
		match, _ := regexp.MatchString("([0-9]+)", a)
		if !match {
			fmt.Println("###### This string has no numbers: ")
		}
		fmt.Println("Random string: ", a)
	}
}
```

And one of the outputs of this test:

```
Random string:  9OyWQ7paZ6
Random string:  qQ47j1L8la
Random string:  AMabYevo22
Random string:  F6ohCHyjUs
Random string:  lTbrBkJ5dK
Random string:  ZliU9eaJPF
###### This string has no numbers:
Random string:  GOltNlZafR 
Random string:  wzy5RHUDiD
###### This string has no numbers:
Random string:  EBLPBCAYSm 
Random string:  chjWlJ494P
```

So each time the random string generated is not alpha numeric, you will see this error in the helm chart of Magento:

```
08:31:36 [testChart] nami    INFO  Initializing php
08:31:36 [testChart] nami    INFO  php successfully initialized
08:31:36 [testChart] nami    INFO  Initializing magento
08:31:36 [testChart] Error executing 'postInstallation': The admin password must contain both letters and numbers.
```

It would be nice to add this to the repo in order to generate always alpha numeric strings. Another solution of this will be concatenating a random string of numbers and a random string of characters in the helm template of the password of Magento, but that would decrease the entropy of the password, making it easier to hack.

> Note: after adding the patch and testing the strings with `10000` random strings works as expected.
> Also, this case can be extended to any other application with password validation in the installation process.

Best regards!