### PR TITLE
Minor changes necessary to run `go test` under 1.15

### DIFF
--- a/cryptorandomstringutils.go
+++ b/cryptorandomstringutils.go
@@ -115,7 +115,7 @@ func CryptoRandomAlphaNumeric(count int) (string, error) {
 		//Get the position between 0 and the length of the string-1  to insert a random number
 		position := getCryptoRandomInt(count)
 		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string(rune('0' + getCryptoRandomInt(10))) + RandomString[position + 1:]
+		RandomString = RandomString[:position] + string(rune('0'+getCryptoRandomInt(10))) + RandomString[position+1:]
 		return RandomString, err
 	}
 	return RandomString, err
@@ -204,7 +204,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/cryptorandomstringutils.go
+++ b/cryptorandomstringutils.go
@@ -115,7 +115,7 @@ func CryptoRandomAlphaNumeric(count int) (string, error) {
 		//Get the position between 0 and the length of the string-1  to insert a random number
 		position := getCryptoRandomInt(count)
 		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
+		RandomString = RandomString[:position] + string(rune('0' + getCryptoRandomInt(10))) + RandomString[position + 1:]
 		return RandomString, err
 	}
 	return RandomString, err

--- a/randomstringutils.go
+++ b/randomstringutils.go
@@ -115,7 +115,7 @@ func RandomAlphaNumeric(count int) (string, error) {
 		//Get the position between 0 and the length of the string-1  to insert a random number
 		position := rand.Intn(count)
 		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
+		RandomString = RandomString[:position] + string(rune('0'+rand.Intn(10))) + RandomString[position+1:]
 		return RandomString, err
 	}
 	return RandomString, err


### PR DESCRIPTION
In Go 1.15, converting from non-byte or -rune integer types directly to a string became a `go vet` warning, enabled by default when running `go test`. Goutils was using this conversion correctly, so mechanically wrapping an additional conversion to `rune` (as suggested by the Go 1.15
changelog) at the warning sites allows `go test` to run without errors on recent Go toolchains.